### PR TITLE
Fix #32: Use the new API of jsdom v10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ jdk:
 env:
   - JSDOM_VERSION=9.12.0
   - JSDOM_VERSION=10.0.0
+  - JSDOM_VERSION=16.0.0
 install:
   # We need a recent version of Node.js for jsdom
-  - nvm install 6
-  - nvm use 6
+  - nvm install 12
+  - nvm use 12
   - node --version
   # Of course we need jsdom
   - npm install jsdom@$JSDOM_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,7 @@ install:
   - npm install jsdom@$JSDOM_VERSION
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalajs-env-jsdom-nodejs/test scalajs-env-jsdom-nodejs/doc
-  - |
-      if [[ "${TRAVIS_SCALA_VERSION}" != "2.10.7" ]]; then
-        sbt ++$TRAVIS_SCALA_VERSION test-project/run test-project/test
-      fi
+  - sbt ++$TRAVIS_SCALA_VERSION test-project/run test-project/test
 cache:
   directories:
     - $HOME/.ivy2/cache

--- a/jsdom-nodejs-env/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
+++ b/jsdom-nodejs-env/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
@@ -75,43 +75,83 @@ class JSDOMNodeJSEnv(config: JSDOMNodeJSEnv.Config) extends JSEnv {
     val scriptsURIs = scripts.map(JSDOMNodeJSEnv.materialize(_))
     val scriptsURIsAsJSStrings =
       scriptsURIs.map(uri => "\"" + escapeJS(uri.toASCIIString) + "\"")
+    val scriptsURIsJSArray = scriptsURIsAsJSStrings.mkString("[", ", ", "]")
     val jsDOMCode = {
       s"""
+         |
          |(function () {
-         |  var jsdom;
-         |  try {
-         |    jsdom = require("jsdom/lib/old-api.js"); // jsdom >= 10.x
-         |  } catch (e) {
-         |    jsdom = require("jsdom"); // jsdom <= 9.x
-         |  }
+         |  var jsdom = require("jsdom");
          |
-         |  var virtualConsole = jsdom.createVirtualConsole()
-         |    .sendTo(console, { omitJsdomErrors: true });
-         |  virtualConsole.on("jsdomError", function (error) {
-         |    /* This inelegant if + console.error is the only way I found
-         |     * to make sure the stack trace of the original error is
-         |     * printed out.
-         |     */
-         |    if (error.detail && error.detail.stack)
-         |      console.error(error.detail.stack);
-         |
-         |    // Throw the error anew to make sure the whole execution fails
-         |    throw error;
-         |  });
-         |
-         |  jsdom.env({
-         |    html: "",
-         |    url: "http://localhost/",
-         |    virtualConsole: virtualConsole,
-         |    created: function (error, window) {
-         |      if (error == null) {
-         |        window["scalajsCom"] = global.scalajsCom;
-         |      } else {
-         |        throw error;
+         |  if (typeof jsdom.JSDOM === "function") {
+         |    // jsdom >= 10.0.0
+         |    var virtualConsole = new jsdom.VirtualConsole()
+         |      .sendTo(console, { omitJSDOMErrors: true });
+         |    virtualConsole.on("jsdomError", function (error) {
+         |      try {
+         |        // Display as much info about the error as possible
+         |        if (error.detail && error.detail.stack) {
+         |          console.error("" + error.detail);
+         |          console.error(error.detail.stack);
+         |        } else {
+         |          console.error(error);
+         |        }
+         |      } finally {
+         |        // Whatever happens, kill the process so that the run fails
+         |        process.exit(1);
          |      }
-         |    },
-         |    scripts: [${scriptsURIsAsJSStrings.mkString(", ")}]
-         |  });
+         |    });
+         |
+         |    var dom = new jsdom.JSDOM("", {
+         |      virtualConsole: virtualConsole,
+         |      url: "http://localhost/",
+         |
+         |      /* Allow unrestricted <script> tags. This is exactly as
+         |       * "dangerous" as the arbitrary execution of script files we
+         |       * do in the non-jsdom Node.js env.
+         |       */
+         |      resources: "usable",
+         |      runScripts: "dangerously"
+         |    });
+         |
+         |    var window = dom.window;
+         |    window["scalajsCom"] = global.scalajsCom;
+         |
+         |    var scriptsSrcs = $scriptsURIsJSArray;
+         |    for (var i = 0; i < scriptsSrcs.length; i++) {
+         |      var script = window.document.createElement("script");
+         |      script.src = scriptsSrcs[i];
+         |      window.document.body.appendChild(script);
+         |    }
+         |  } else {
+         |    // jsdom v9.x
+         |    var virtualConsole = jsdom.createVirtualConsole()
+         |      .sendTo(console, { omitJsdomErrors: true });
+         |    virtualConsole.on("jsdomError", function (error) {
+         |      /* This inelegant if + console.error is the only way I found
+         |       * to make sure the stack trace of the original error is
+         |       * printed out.
+         |       */
+         |      if (error.detail && error.detail.stack)
+         |        console.error(error.detail.stack);
+         |
+         |      // Throw the error anew to make sure the whole execution fails
+         |      throw error;
+         |    });
+         |
+         |    jsdom.env({
+         |      html: "",
+         |      virtualConsole: virtualConsole,
+         |      url: "http://localhost/",
+         |      created: function (error, window) {
+         |        if (error == null) {
+         |          window["scalajsCom"] = global.scalajsCom;
+         |        } else {
+         |          throw error;
+         |        }
+         |      },
+         |      scripts: $scriptsURIsJSArray
+         |    });
+         |  }
          |})();
          |""".stripMargin
     }


### PR DESCRIPTION
This is a forward-port of the upstream commit https://github.com/scala-js/scala-js/commit/8d1938b6eaa985c933189f0eaf82edee0b3cb897

In this commit, we preserve the status quo of this codebase for jsdom v9. The code in 0.6.x (with the simpler `virtualConsole.sendTo` call) does not pass the full test suite.

However, for v10+, we use exactly the same code as in the latest Scala.js 0.6.x, coming from the above commit.