### PR TITLE
Depend on scalajs-env-nodejs 1.0.0-RC2, not SNAPSHOT.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0-RC2")
 
-libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.0.0-SNAPSHOT"
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.0.0-RC2"
 
 unmanagedSourceDirectories in Compile +=
   baseDirectory.value.getParentFile / "jsdom-nodejs-env/src/main/scala"


### PR DESCRIPTION
This was erroneously changed in 39395f33bf8d95f64ae175cf46ea1d23770a37d8.