### PR TITLE
FF ONLY Version 1.0.0-RC3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 inThisBuild(Seq(
-  version := "1.0.0-SNAPSHOT",
+  version := "1.0.0-RC3",
   organization := "org.scala-js",
 
   crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1"),


### PR DESCRIPTION
This provides a quickly released fix to the fact that 1.0.0-RC2 does not support jsdom >= 12 at all.

Releasing such a 1.0.0-RC3, that is still built against Scala.js 1.0.0-RC2, is not fundamentally problematic (the version numbers don't have to match), but it will introduce a shift in the version numbers in case we publish more RCs for Scala.js. Given that further RCs are pretty unlikely at this point, I believe this is the best way to unblock codebases that need jsdom to be tested and published for Scala.js 1.0.0-RC2.