### PR TITLE
Drop support for jsdom 9.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ scala:
 jdk:
   - openjdk8
 env:
-  - JSDOM_VERSION=9.12.0
   - JSDOM_VERSION=10.0.0
   - JSDOM_VERSION=16.0.0
 install:

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 inThisBuild(Seq(
-  version := "1.0.1-SNAPSHOT",
+  version := "1.1.0-SNAPSHOT",
   organization := "org.scala-js",
 
   crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1"),

--- a/jsdom-nodejs-env/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
+++ b/jsdom-nodejs-env/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
@@ -78,79 +78,46 @@ class JSDOMNodeJSEnv(config: JSDOMNodeJSEnv.Config) extends JSEnv {
     val scriptsURIsJSArray = scriptsURIsAsJSStrings.mkString("[", ", ", "]")
     val jsDOMCode = {
       s"""
-         |
          |(function () {
          |  var jsdom = require("jsdom");
          |
-         |  if (typeof jsdom.JSDOM === "function") {
-         |    // jsdom >= 10.0.0
-         |    var virtualConsole = new jsdom.VirtualConsole()
-         |      .sendTo(console, { omitJSDOMErrors: true });
-         |    virtualConsole.on("jsdomError", function (error) {
-         |      try {
-         |        // Display as much info about the error as possible
-         |        if (error.detail && error.detail.stack) {
-         |          console.error("" + error.detail);
-         |          console.error(error.detail.stack);
-         |        } else {
-         |          console.error(error);
-         |        }
-         |      } finally {
-         |        // Whatever happens, kill the process so that the run fails
-         |        process.exit(1);
-         |      }
-         |    });
-         |
-         |    var dom = new jsdom.JSDOM("", {
-         |      virtualConsole: virtualConsole,
-         |      url: "http://localhost/",
-         |
-         |      /* Allow unrestricted <script> tags. This is exactly as
-         |       * "dangerous" as the arbitrary execution of script files we
-         |       * do in the non-jsdom Node.js env.
-         |       */
-         |      resources: "usable",
-         |      runScripts: "dangerously"
-         |    });
-         |
-         |    var window = dom.window;
-         |    window["scalajsCom"] = global.scalajsCom;
-         |
-         |    var scriptsSrcs = $scriptsURIsJSArray;
-         |    for (var i = 0; i < scriptsSrcs.length; i++) {
-         |      var script = window.document.createElement("script");
-         |      script.src = scriptsSrcs[i];
-         |      window.document.body.appendChild(script);
-         |    }
-         |  } else {
-         |    // jsdom v9.x
-         |    var virtualConsole = jsdom.createVirtualConsole()
-         |      .sendTo(console, { omitJsdomErrors: true });
-         |    virtualConsole.on("jsdomError", function (error) {
-         |      /* This inelegant if + console.error is the only way I found
-         |       * to make sure the stack trace of the original error is
-         |       * printed out.
-         |       */
-         |      if (error.detail && error.detail.stack)
+         |  var virtualConsole = new jsdom.VirtualConsole()
+         |    .sendTo(console, { omitJSDOMErrors: true });
+         |  virtualConsole.on("jsdomError", function (error) {
+         |    try {
+         |      // Display as much info about the error as possible
+         |      if (error.detail && error.detail.stack) {
+         |        console.error("" + error.detail);
          |        console.error(error.detail.stack);
+         |      } else {
+         |        console.error(error);
+         |      }
+         |    } finally {
+         |      // Whatever happens, kill the process so that the run fails
+         |      process.exit(1);
+         |    }
+         |  });
          |
-         |      // Throw the error anew to make sure the whole execution fails
-         |      throw error;
-         |    });
+         |  var dom = new jsdom.JSDOM("", {
+         |    virtualConsole: virtualConsole,
+         |    url: "http://localhost/",
          |
-         |    jsdom.env({
-         |      html: "",
-         |      virtualConsole: virtualConsole,
-         |      url: "http://localhost/",
-         |      created: function (error, window) {
-         |        if (error == null) {
-         |          window["scalajsCom"] = global.scalajsCom;
-         |        } else {
-         |          throw error;
-         |        }
-         |      },
-         |      scripts: $scriptsURIsJSArray
-         |    });
+         |    /* Allow unrestricted <script> tags. This is exactly as
+         |     * "dangerous" as the arbitrary execution of script files we
+         |     * do in the non-jsdom Node.js env.
+         |     */
+         |    resources: "usable",
+         |    runScripts: "dangerously"
+         |  });
+         |
+         |  var window = dom.window;
+         |  window["scalajsCom"] = global.scalajsCom;
+         |
+         |  var scriptsSrcs = $scriptsURIsJSArray;
+         |  for (var i = 0; i < scriptsSrcs.length; i++) {
+         |    var script = window.document.createElement("script");
+         |    script.src = scriptsSrcs[i];
+         |    window.document.body.appendChild(script);
          |  }
          |})();
          |""".stripMargin


### PR DESCRIPTION
jsdom 10.0.0 is 3 years old. We held on to jsdom 9.x until now because we wanted an upgrade path from Scala.js 0.6.x, which has historically supported jsdom 9.x. Now it is time to move on.

---

Best reviewed with the "Hide whitespace changes" option enabled.