### PR TITLE
Add Scala 3 cross-build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scalaversion: ["2.11.12", "2.12.10", "2.13.1"]
+        scalaversion: ["2.12.21", "2.11.12", "2.13.18", "3.3.8"]
         jsdomversion: ["10.0.0", "16.0.0", "21.0.0", "27.0.0"]
         include:
           - jsdomversion: 10.0.0
@@ -44,4 +44,7 @@ jobs:
       - name: Doc generation
         run: sbt "++${{ matrix.scalaversion }}" scalajs-env-jsdom-nodejs/doc
       - name: Integration tests
+        # scala-js 1.13.0 dropped 2.11 support,
+        # while later version is required for testing on scala3.
+        if: matrix.scalaversion != '2.11.12'
         run: sbt "++${{ matrix.scalaversion }}" test-project/run test-project/test

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,13 @@
 inThisBuild(Seq(
   organization := "org.scala-js",
 
-  crossScalaVersions := Seq("2.12.10", "2.11.12", "2.13.1"),
+  crossScalaVersions := Seq("2.12.21", "2.11.12", "2.13.18", "3.3.8"),
   scalaVersion := crossScalaVersions.value.head,
-  scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
+  scalacOptions ++= Seq("-deprecation", "-feature"),
+  scalacOptions ++= {
+    if (scalaVersion.value.startsWith("3.")) Seq("-Werror")
+    else Seq("-Xfatal-warnings")
+  },
 
   homepage := Some(url("https://www.scala-js.org/")),
   licenses += ("BSD New",
@@ -14,6 +18,8 @@ inThisBuild(Seq(
       Some("scm:git:git@github.com:scala-js/scala-js-env-jsdom-nodejs.git"))),
   versionScheme := Some("semver-spec"),
 ))
+
+val jsEnvsVersion = "1.6.0"
 
 val commonSettings = Def.settings(
   // Scaladoc linking
@@ -57,11 +63,11 @@ lazy val `scalajs-env-jsdom-nodejs`: Project = project.in(file("jsdom-nodejs-env
     commonSettings,
 
     libraryDependencies ++= Seq(
-      "org.scala-js" %% "scalajs-js-envs" % scalaJSVersion,
-      "org.scala-js" %% "scalajs-env-nodejs" % scalaJSVersion,
+      "org.scala-js" %% "scalajs-js-envs" % jsEnvsVersion,
+      "org.scala-js" %% "scalajs-env-nodejs" % jsEnvsVersion,
 
       "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.scala-js" %% "scalajs-js-envs-test-kit" % scalaJSVersion % "test",
+      "org.scala-js" %% "scalajs-js-envs-test-kit" % jsEnvsVersion % "test",
 
       /* See JSDOMNodeJSEnvTest.reactUnhandledExceptionHack.
        * We use intransitive() because we do not need the transitive

--- a/jsdom-nodejs-env/src/test/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSSuite.scala
+++ b/jsdom-nodejs-env/src/test/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSSuite.scala
@@ -5,4 +5,8 @@ import org.scalajs.jsenv.test._
 import org.junit.runner.RunWith
 
 @RunWith(classOf[JSEnvSuiteRunner])
-class JSDOMNodeJSSuite extends JSEnvSuite(JSEnvSuiteConfig(new JSDOMNodeJSEnv))
+class JSDOMNodeJSSuite extends JSEnvSuite(
+  JSEnvSuiteConfig(new JSDOMNodeJSEnv) // currently, JSDomNodeJSEnv only supports Script
+    .withSupportsCommonJSModules(false)
+    .withSupportsESModules(false)
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
-libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.0.0"
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.6.0"
 
 Compile / unmanagedSourceDirectories +=
   baseDirectory.value.getParentFile / "jsdom-nodejs-env/src/main/scala"


### PR DESCRIPTION
cross build for Scala 3 so that sbt2 projects can use `jsdom-nodejs`